### PR TITLE
Fixing typo within english language

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -1137,7 +1137,7 @@
 		{
 			"id": "medium_gas_canister",
 			"label": {
-				"en-US": "Medium Gaz Canister",
+				"en-US": "Medium Gas Canister",
 				"fr-FR": "Bonbonne de gaz moyenne"
 			},
 			"printed": "small_printer",


### PR DESCRIPTION
The actual translation within the game is **gas** and not **gaz**.